### PR TITLE
Adjust styles for top

### DIFF
--- a/components/pages/top/Background.vue
+++ b/components/pages/top/Background.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-  .root.fade-in-on-background
+  .root.fade-in-on-background(:style="style")
     transition(appear @enter='enter')
       template(v-if='isSp()')
         img(src='~/assets/images/sunset_sp.jpg')
@@ -11,6 +11,21 @@
 import {TweenMax} from 'gsap'
 
 export default {
+  computed: {
+    style() {
+      return `height: ${this.height}px`;
+    }
+  },
+  created() {
+    if (process.browser) {
+      return this.height = window.innerHeight;
+    }
+  },
+  data() {
+    return {
+      height: 0,
+    };
+  },
   methods: {
     async enter(el, done) {
       await this.$delay(2000);
@@ -30,13 +45,12 @@ export default {
   align-items center
   display flex
   flex-wrap: wrap
-  height 100vh
   justify-content space-around
   position absolute
   width 100%
 img
   filter brightness(60%)
-  height 101vh
+  height 105%
   left 0
   margin auto
   object-fit cover

--- a/components/pages/top/SwitchText.vue
+++ b/components/pages/top/SwitchText.vue
@@ -70,7 +70,7 @@ export default {
 <style lang="stylus" scoped>
 .root
   font-size 15px
-  font-weight 100
+  font-weight 200
   line-height: 1.5em
   padding-bottom 15px
   position relative

--- a/components/pages/top/TitleText.vue
+++ b/components/pages/top/TitleText.vue
@@ -12,6 +12,6 @@ span
   letter-spacing 4px
   text-align center
   position relative
-  font-weight 150
+  font-weight 300
   padding-bottom 15px
 </style>


### PR DESCRIPTION
トップ周りのレイアウト調整、
特に背景画像を `100vh` で指定しまうと、トップ画像の下の方が見えず意図と反するため改修。
単純に `100%` にすると、ワイプアニメーションの際にワイプと一緒にサイズが変わってしまうため、vueを使ってheightを指定した。