### PR TITLE
Go to next page when scroll down

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -13,6 +13,11 @@ import aboutBackground from '~/components/pages/about/Background'
 import draggable from '~/plugins/draggable';
 import wheelable from '~/plugins/wheelable';
 
+const currentPathToNextPath = {
+  'index': 'about',
+  'about': '/',
+};
+
 export default {
   components: {
     indexBackground,
@@ -25,8 +30,8 @@ export default {
   },
   created() {
     if (process.browser) {
-      window.addEventListener('keyup', function(e) {
-        console.log(e.key === 'ArrowDown');
+      window.addEventListener('keyup', (e) => {
+        this.goNextPage();
       });
     }
   },
@@ -37,10 +42,15 @@ export default {
   },
   methods: {
     eventWhenScrolledDown() {
-      console.log('scrolled down');
+      this.goNextPage();
     },
     eventWhenWheeledDown() {
-      console.log('wheeled down');
+      this.goNextPage();
+    },
+    goNextPage() {
+      const currentPath = this.$router.currentRoute.name;
+      const nextPath = currentPathToNextPath[currentPath];
+      this.$router.push(nextPath);
     },
   },
   mixins: [

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -23,6 +23,13 @@ export default {
       return this.currentPage + 'Background';
     }
   },
+  created() {
+    if (process.browser) {
+      window.addEventListener('keyup', function(e) {
+        console.log(e.key === 'ArrowDown');
+      });
+    }
+  },
   data() {
     return {
       currentPage: 'index',

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,5 @@
 <template>
-  <div @touchstart="startTouch($event)" @touchmove.prevent="onTouch($event)" @touchend="stopDrag($event)" @mousedown="startDrag($event)" @mousemove.prevent="onDrag($event)" @mouseup="stopDrag($event)">
+  <div @touchstart="startTouch($event)" @touchmove.prevent="onTouch($event)" @touchend="stopDrag($event)" @mousedown="startDrag($event)" @mousemove.prevent="onDrag($event)" @mouseup="stopDrag($event)" @wheel="onWheel($event)">
     <div class="header">
     </div>
     <nuxt/>
@@ -11,6 +11,7 @@
 import indexBackground from '~/components/pages/top/BlackBackground'
 import aboutBackground from '~/components/pages/about/Background'
 import draggable from '~/plugins/draggable';
+import wheelable from '~/plugins/wheelable';
 
 export default {
   components: {
@@ -31,8 +32,14 @@ export default {
     eventWhenScrolledDown() {
       console.log('scrolled down');
     },
+    eventWhenWheeledDown() {
+      console.log('wheeled down');
+    },
   },
-  mixins: [draggable],
+  mixins: [
+    draggable,
+    wheelable,
+  ],
   watch: {
     '$route' (to, from) {
       this.currentPage = to.name;

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -41,7 +41,7 @@ export default {
     }
   },
   methods: {
-    eventWhenScrolledDown() {
+    eventWhenDraggedUp() {
       this.goNextPage();
     },
     eventWhenWheeledDown() {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,5 @@
 <template>
-  <div @touchmove.prevent="doNothing($event)">
+  <div @touchstart="startTouch($event)" @touchmove.prevent="onTouch($event)" @touchend="stopDrag($event)" @mousedown="startDrag($event)" @mousemove.prevent="onDrag($event)" @mouseup="stopDrag($event)">
     <div class="header">
     </div>
     <nuxt/>
@@ -10,6 +10,7 @@
 <script>
 import indexBackground from '~/components/pages/top/BlackBackground'
 import aboutBackground from '~/components/pages/about/Background'
+import draggable from '~/plugins/draggable';
 
 export default {
   components: {
@@ -27,8 +28,11 @@ export default {
     }
   },
   methods: {
-    doNothing() {},
+    eventWhenScrolledDown() {
+      console.log('scrolled down');
+    },
   },
+  mixins: [draggable],
   watch: {
     '$route' (to, from) {
       this.currentPage = to.name;

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -50,7 +50,7 @@ export default {
       });
       wipe1(el, done, '#index');
     }
-  }
+  },
 }
 </script>
 

--- a/plugins/draggable.js
+++ b/plugins/draggable.js
@@ -4,7 +4,7 @@
 // 1. Import this plugin as mixin. ex. `mixins: [draggable]`
 // 2. Write following to your html.
 // <div @touchstart="startTouch($event)" @touchmove.prevent="onTouch($event)" @touchend="stopDrag($event)" @mousedown="startDrag($event)" @mousemove.prevent="onDrag($event)" @mouseup="stopDrag($event)">
-// 3. Implement `eventWhenScrolled**` to methods on your components, or use variables on data as you like.
+// 3. Implement `eventWhenDragged**` to methods on your components, or use variables on data as you like.
 
 class Direction {
   constructor(direction) {
@@ -75,14 +75,14 @@ export default {
       this.dragStartY = e.changedTouches[0].pageY;
     },
     stopDrag(_e) {
-      if (this.dragLengthX < -50) {
-        this.eventWhenScrolledRight();
-      } else if (this.dragLengthX > 50) {
-        this.eventWhenScrolledLeft();
-      } else if (this.dragLengthY > 50) {
-        this.eventWhenScrolledDown();
-      } else if (this.dragLengthY < -50) {
-        this.eventWhenScrolledUp();
+      if (this.dragLengthY > 20) {
+        this.eventWhenDraggedDown();
+      } else if (this.dragLengthY < -20) {
+        this.eventWhenDraggedUp();
+      } else if (this.dragLengthX < -20) {
+        this.eventWhenDraggedRight();
+      } else if (this.dragLengthX > 20) {
+        this.eventWhenDraggedLeft();
       }
       this.dragStartX = null;
       this.dragStartY = null;
@@ -99,9 +99,9 @@ export default {
     },
 
     // please override here
-    eventWhenScrolledRight() {},
-    eventWhenScrolledLeft() {},
-    eventWhenScrolledDown() {},
-    eventWhenScrolledUp() {},
+    eventWhenDraggedRight() {},
+    eventWhenDraggedLeft() {},
+    eventWhenDraggedDown() {},
+    eventWhenDraggedUp() {},
   },
 };

--- a/plugins/draggable.js
+++ b/plugins/draggable.js
@@ -1,0 +1,107 @@
+// mixin plugin to controll drag event on your vue component.
+//
+// How to use
+// 1. Import this plugin as mixin. ex. `mixins: [draggable]`
+// 2. Write following to your html.
+// <div @touchstart="startTouch($event)" @touchmove.prevent="onTouch($event)" @touchend="stopDrag($event)" @mousedown="startDrag($event)" @mousemove.prevent="onDrag($event)" @mouseup="stopDrag($event)">
+// 3. Implement `eventWhenScrolled**` to methods on your components, or use variables on data as you like.
+
+class Direction {
+  constructor(direction) {
+    this.direction = direction;
+  }
+
+  get isHorizontal() {
+    return this.direction === 'horizontal';
+  }
+
+  get isVertical() {
+    return this.direction === 'vertical';
+  }
+}
+
+const VERTICAL = new Direction('vertical');
+const HORIZONTAL = new Direction('horizontal');
+
+export default {
+  computed: {
+    dragLengthX() {
+      if (this.dragStartX === null || this.draggingX === null) {
+        return 0;
+      }
+      return this.draggingX - this.dragStartX;
+    },
+    dragLengthY() {
+      if (this.dragStartY === null || this.draggingY === null) {
+        return 0;
+      }
+      return this.draggingY - this.dragStartY;
+    },
+  },
+  data() {
+    return {
+      draggingX: null,
+      draggingY: null,
+      dragStartX: null,
+      dragStartY: null,
+      initialDragDirection: null,
+    };
+  },
+  methods: {
+    onDrag(e) {
+      this.draggingX = e.pageX;
+      this.draggingY = e.pageY;
+      if (!this.initialDragDirection && Math.abs(this.dragLengthX) > 10) {
+        this.initialDragDirection = HORIZONTAL;
+      } else if (!this.initialDragDirection && Math.abs(this.dragLengthY) > 10) {
+        this.initialDragDirection = VERTICAL;
+      }
+    },
+    onTouch(e) {
+      this.draggingX = e.changedTouches[0].pageX;
+      this.draggingY = e.changedTouches[0].pageY;
+      if (!this.initialDragDirection && Math.abs(this.dragLengthX) > 10) {
+        this.initialDragDirection = HORIZONTAL;
+      } else if (!this.initialDragDirection && Math.abs(this.dragLengthY) > 10) {
+        this.initialDragDirection = VERTICAL;
+      }
+    },
+    startDrag(e) {
+      this.dragStartX = e.pageX;
+      this.dragStartY = e.pageY;
+    },
+    startTouch(e) {
+      this.dragStartX = e.changedTouches[0].pageX;
+      this.dragStartY = e.changedTouches[0].pageY;
+    },
+    stopDrag(_e) {
+      if (this.dragLengthX < -50) {
+        this.eventWhenScrolledRight();
+      } else if (this.dragLengthX > 50) {
+        this.eventWhenScrolledLeft();
+      } else if (this.dragLengthY > 50) {
+        this.eventWhenScrolledDown();
+      } else if (this.dragLengthY < -50) {
+        this.eventWhenScrolledUp();
+      }
+      this.dragStartX = null;
+      this.dragStartY = null;
+      this.draggingX = null;
+      this.draggingY = null;
+      this.initialDragDirection = null;
+    },
+    stopTouch(_e) {
+      this.dragStartX = null;
+      this.dragStartY = null;
+      this.draggingX = null;
+      this.draggingY = null;
+      this.initialDragDirection = null;
+    },
+
+    // please override here
+    eventWhenScrolledRight() {},
+    eventWhenScrolledLeft() {},
+    eventWhenScrolledDown() {},
+    eventWhenScrolledUp() {},
+  },
+};

--- a/plugins/wheelable.js
+++ b/plugins/wheelable.js
@@ -1,0 +1,76 @@
+// mixin plugin to controll wheel event on your vue component.
+//
+// How to use
+// 1. Import this plugin as mixin. ex. `mixins: [wheelable]`
+// 2. Write following to your html.
+// <div @wheel="onWheel($event)">
+// 3. Implement `eventWhenWheeled**` to methods on your components, or use variables on data as you like.
+
+class Direction {
+  constructor(direction) {
+    this.direction = direction;
+  }
+
+  get isHorizontal() {
+    return this.direction === 'horizontal';
+  }
+
+  get isVertical() {
+    return this.direction === 'vertical';
+  }
+}
+
+const VERTICAL = new Direction('vertical');
+const HORIZONTAL = new Direction('horizontal');
+
+export default {
+  data() {
+    return {
+      lastWheeledAt: 0,
+      maxWheelX: 0,
+      maxWheelY: 0,
+      initialWheelDirection: null,
+    };
+  },
+  methods: {
+    onWheel(e) {
+      this.maxWheelX = Math.max(this.maxWheelX, e.deltaX);
+      this.maxWheelY = Math.max(this.maxWheelY, e.deltaY);
+      if (!this.initialWheelDirection && Math.abs(this.maxWheelX) > 3) {
+        this.initialWheelDirection = HORIZONTAL;
+      } else if (!this.initialWheelDirection && Math.abs(this.maxWheelY) > 3) {
+        this.initialWheelDirection = VERTICAL;
+      }
+
+      const wheeledAt = Date.now();
+      this.lastWheeledAt = wheeledAt;
+      setTimeout(() => {
+        if (this.lastWheeledAt === wheeledAt) {
+          this.stopWheel();
+        }
+      }, 100)
+    },
+    stopWheel(_e) {
+      if (this.maxWheelX < -10) {
+        this.eventWhenWheeledRight();
+      } else if (this.maxWheelX > 10) {
+        this.eventWhenWheeledLeft();
+      } else if (this.maxWheelY > 10) {
+        this.eventWhenWheeledDown();
+      } else if (this.maxWheelY < -10) {
+        this.eventWhenWheeledUp();
+      }
+      this.wheelStartX = null;
+      this.wheelStartY = null;
+      this.maxWheelX = null;
+      this.maxWheelY = null;
+      this.initialWheelDirection = null;
+    },
+
+    // please override here
+    eventWhenWheeledRight() {},
+    eventWhenWheeledLeft() {},
+    eventWhenWheeledDown() {},
+    eventWhenWheeledUp() {},
+  },
+};


### PR DESCRIPTION
下スクロール時に次ページにいくようにした。

単純にこれを実装しようとすれば `onscroll` などを使えば良いが、
今回はアプリっぽい見た目にするため、一切のスクロールを禁止しており、scrollイベントが発火しない。
そのため、以下のイベントを直接ハンドリングすることで、下スクロールの検知を行った。

* `ontouch` : スマホでのタッチスクロールの検知(dragとみなして、ついでにdragもハンドリングしている)
* `onwheel` : PCでのマウスホイールダウン、タッチパッドでのスクロール
* `onkeyup` : 下矢印の検知