### PR TITLE
Handle dragging down

### DIFF
--- a/mixins/handleScroll.js
+++ b/mixins/handleScroll.js
@@ -16,6 +16,9 @@ export default {
     eventWhenDraggingUp() {
       this.goNextPage();
     },
+    eventWhenDraggingDown() {
+      this.goPrevPage();
+    },
     eventWhenWheelingDown() {
       this.goNextPage();
     },

--- a/mixins/handleScroll.js
+++ b/mixins/handleScroll.js
@@ -20,7 +20,7 @@ export default {
       this.goPrevPage();
     },
     eventWhenWheelingDown() {
-      this.goNextPage();
+      this.goNextPage(); // see https://github.com/nullnull/portfolio/pull/21
     },
     eventWhenWheelingUp() {
       this.goNextPage();

--- a/mixins/pageHandler.js
+++ b/mixins/pageHandler.js
@@ -1,12 +1,21 @@
-const currentPathToNextPath = {
-  'index': '/about',
-  'about': '/lovegraph',
-  'lovegraph': '/dena',
-  'dena': '/univ',
-  'univ': '/photography',
-  'photography': '/contact',
-  'contact': '/',
-};
+const paths = ['/', '/about', '/lovegraph', '/dena', '/univ', '/photography', '/contact']
+const pathsWithFallback = [null, ...paths, null]
+
+function getNextPath(targetPath) {
+  const index = pathsWithFallback.findIndex(path => path === targetPath);
+  return pathsWithFallback[index + 1];
+}
+
+function getPrevPath(targetPath) {
+  const index = pathsWithFallback.findIndex(path => path === targetPath);
+  return pathsWithFallback[index - 1];
+}
+
+function moveTo(vue, path) {
+  vue.$store.commit('startPageTransition');
+  vue.$router.push(path);
+  setTimeout(() => vue.$store.commit('stopPageTransition'), 3000); // NOT GOOD IMPLEMENTATION
+}
 
 export default {
   methods: {
@@ -14,14 +23,19 @@ export default {
       if (this.$store.state.menuVisibility || this.$store.state.isPageTransitioning) {
         return;
       }
-      const currentPath = this.$router.currentRoute.name;
-      if (currentPath === 'contact') {
+      const nextPath = getNextPath(this.$router.currentRoute.path);
+      if (nextPath) {
+        moveTo(this, nextPath);
+      }
+    },
+    goPrevPage() {
+      if (this.$store.state.menuVisibility || this.$store.state.isPageTransitioning) {
         return;
       }
-      const nextPath = currentPathToNextPath[currentPath];
-      this.$store.commit('startPageTransition');
-      this.$router.push(nextPath);
-      setTimeout(() => this.$store.commit('stopPageTransition'), 3000); // NOT GOOD IMPLEMENTATION
+      const prevPath = getPrevPath(this.$router.currentRoute.path);
+      if (prevPath) {
+        moveTo(this, prevPath);
+      }
     },
   },
 };


### PR DESCRIPTION
スマホの上スワイプ(前のページに戻る)に対応し忘れていたので追加。ガハハハ。

※PC版に関しては、今回の実装ではonscrollではなくonwheelイベントを使っている https://github.com/nullnull/portfolio/pull/7 影響と、
wheelの向きとscrollの向きは、macbookのトラックパッドの設定に依存するという理由で、
現在下にいこうとしてるのか上にいきたいのかが分からず、どちらも `goNextPage` する実装にしている。
（が、スマホはこうする必要がなく、こっちは単純に実装を忘れていた）